### PR TITLE
lifecycle: add error handlers

### DIFF
--- a/test/manifold/lifecycle_test.clj
+++ b/test/manifold/lifecycle_test.clj
@@ -83,6 +83,10 @@
                                     (step inc)
                                     (step inc)])))
 
+  (is (= {:x 1} @(run {:x 0} [(step :inc inc :lens :x)])))
+
+  (is (= {:x 0} @(run {:x 0} [(step :inc inc :lens :x :guard (constantly false))])))
+
   (is (= {:x 0}
          @(run {:x 0} [(step :inc inc
                              :lens :x
@@ -125,8 +129,51 @@
 
 
 (deftest build-stages-test
+
   (is (=
-       (build-stages {:stages [:enter :leave] :stop-on :stop! :augment 'augment}
+       (build-stages {:stop-on :stop! :augment 'augment}
+                     [{:id :format :enter 'deserialize :leave 'serialize :error :eformat}
+                      {:id :normalize :enter 'normalize-in :leave 'normalize-out}
+                      {:id :validate :enter 'validate :error :evalidate}
+                      {:id :handler :enter 'runcmd :error :ehandler}])
+       '[{:id :format,
+          :error (:eformat),
+          :stage :enter,
+          :handler deserialize,
+          :augment augment,
+          :stop-on :stop!}
+         {:id :normalize,
+          :stage :enter,
+          :handler normalize-in,
+          :error (:eformat),
+          :augment augment,
+          :stop-on :stop!}
+         {:id :validate,
+          :error (:evalidate :eformat),
+          :stage :enter,
+          :handler validate,
+          :augment augment,
+          :stop-on :stop!}
+         {:id :handler,
+          :error (:ehandler :evalidate :eformat),
+          :stage :enter,
+          :handler runcmd,
+          :augment augment,
+          :stop-on :stop!}
+         {:id :normalize,
+          :stage :leave,
+          :handler normalize-out,
+          :error (:eformat),
+          :augment augment,
+          :stop-on :stop!}
+         {:id :format,
+          :error (:eformat),
+          :stage :leave,
+          :handler serialize,
+          :augment augment,
+          :stop-on :stop!}]))
+  (is (=
+       (build-stages {:stop-on :stop! :augment 'augment}
                      [{:id :request-id :enter 'add-request}
                       {:id :route :enter 'route}
                       {:id :format :enter 'deserialize :leave 'serialize}
@@ -136,40 +183,67 @@
        '[{:id :request-id,
           :stage :enter,
           :handler add-request,
+          :error []
           :stop-on :stop!,
           :augment augment}
          {:id :route,
           :stage :enter,
           :handler route,
+          :error []
           :stop-on :stop!,
           :augment augment}
          {:id :format,
           :stage :enter,
           :handler deserialize,
+          :error []
           :stop-on :stop!,
           :augment augment}
          {:id :normalize,
           :stage :enter,
           :handler normalize-in,
+          :error []
           :stop-on :stop!,
           :augment augment}
          {:id :validate,
           :stage :enter,
           :handler validate,
           :stop-on :stop!,
+          :error []
           :augment augment}
          {:id :handler,
           :stage :enter,
           :handler runcmd,
+          :error []
           :stop-on :stop!,
           :augment augment}
          {:id :normalize,
           :stage :leave,
+          :error []
           :handler normalize-out,
           :stop-on :stop!,
           :augment augment}
          {:id :format,
           :stage :leave,
           :handler serialize,
+          :error []
           :stop-on :stop!,
           :augment augment}])))
+
+
+(defn fail!
+  [& _]
+  (throw (ex-info "blah" {})))
+
+(deftest stage-error-handling
+
+  (testing "basic-error-handling"
+    (let [error-handler (constantly 1000)]
+      (is (= [{:id :a :stage :enter :handler fail! :error [error-handler] :stop-on :stop! :augment nil}
+              {:id :a :stage :leave :handler inc :error [error-handler] :stop-on :stop! :augment nil} ]
+             (build-stages {:stop-on :stop!} [(step :a [fail! inc] :error error-handler)]))))
+
+    (is (= @(run 0 [(step :a [fail! inc] :error (constantly 1000))]) 1001))
+    (is (= @(run 0 [(step :a [inc fail!] :error (constantly 1000))]) 1000))
+
+    )
+  )


### PR DESCRIPTION
Following on the interceptor inpiration, add support for an
`:error` key in steps. Error handlers which will receive the
step which threw, the current context and the exception.

If the handler yields a non-throwable value, let processing
continue, otherwise, walk up the chain of handler to try
finding other error handlers